### PR TITLE
Rework of data storage for Profiles

### DIFF
--- a/CHTR_TFAR_Setter/CfgVehicles.hpp
+++ b/CHTR_TFAR_Setter/CfgVehicles.hpp
@@ -63,7 +63,7 @@ class CfgVehicles {
 					class Save_Root {
 						displayName = "Save";
 						statement = "";
-						condition = QUOTE(ALTERNATE_LAYOUT);
+						condition = QUOTE(ALTERNATE_LAYOUT && (SHOW_LR || SHOW_SR) && (HAS_LR || HAS_SR));
 						icon = QUOTE(ICON_PATH(save));
 						class Save_LR {
 							displayName = "LR";
@@ -83,7 +83,7 @@ class CfgVehicles {
 						displayName = "Load";
 						icon = QUOTE(ICON_PATH(load));
 						statement = QUOTE(if(SHORTCUT_ENABLED) then {[true] call FUNC(loadBothSettings)};);
-						condition = QUOTE(ALTERNATE_LAYOUT);
+						condition = QUOTE(ALTERNATE_LAYOUT && (HAS_LR || HAS_SR));
 						class Load_LR {
 							displayName = "LR";
 							icon = QUOTE(ICON_PATH(lr));

--- a/CHTR_TFAR_Setter/CfgVehicles.hpp
+++ b/CHTR_TFAR_Setter/CfgVehicles.hpp
@@ -23,8 +23,8 @@ class CfgVehicles {
 							icon = QUOTE(ICON_PATH(interact_root));
 							statement = QUOTE([true] call FUNC(loadBothSettings));
 							condition = QUOTE(!ALTERNATE_LAYOUT && SHOW_LR && SHOW_SR && HAS_LR && HAS_SR);
-					}
-					//Original Layout, PROFILESETTINGS_PREF_LAYOUT = False
+					};
+					//Original Layout, ALTERNATE_LAYOUT = False
 					class LR_Root {
 						displayName = "LR";
 						icon = QUOTE(ICON_PATH(lr));
@@ -40,7 +40,7 @@ class CfgVehicles {
 							displayName = "Save";
 						};
 					};
-					//Original Layout, PROFILESETTINGS_PREF_LAYOUT = False
+					//Original Layout, ALTERNATE_LAYOUT = False
 					class SR_Root {
 						displayName = "SR";
 						icon = QUOTE(ICON_PATH(sr));
@@ -56,7 +56,7 @@ class CfgVehicles {
 							displayName = "Save";
 						};
 					};
-					//New Layout, PROFILESETTINGS_PREF_LAYOUT = True
+					//New Layout, ALTERNATE_LAYOUT = True
 					class Save_Root {
 						displayName = "Save";
 						statement = "";
@@ -75,7 +75,7 @@ class CfgVehicles {
 							condition = QUOTE(SHOW_SR && HAS_SR);
 						};
 					};
-					//New Layout, PROFILESETTINGS_PREF_LAYOUT = True
+					//New Layout, ALTERNATE_LAYOUT = True
 					class Load_Root {
 						displayName = "Load";
 						icon = QUOTE(ICON_PATH(load));

--- a/CHTR_TFAR_Setter/CfgVehicles.hpp
+++ b/CHTR_TFAR_Setter/CfgVehicles.hpp
@@ -31,12 +31,12 @@ class CfgVehicles {
 						condition = QUOTE(!ALTERNATE_LAYOUT && SHOW_LR && HAS_LR);
 						class LR_Load {
 							icon = QUOTE(ICON_PATH(load));
-							statement = QUOTE(call FUNC(loadLRSettings));
+							statement = QUOTE([true] call FUNC(loadLRSettings));
 							displayName = "Load";
 						};
 						class LR_Save {
 							icon = QUOTE(ICON_PATH(save));
-							statement = QUOTE(call FUNC(saveLRSettings));
+							statement = QUOTE([true] call FUNC(saveLRSettings));
 							displayName = "Save";
 						};
 					};
@@ -47,12 +47,12 @@ class CfgVehicles {
 						condition = QUOTE(!ALTERNATE_LAYOUT && SHOW_SR && HAS_SR);
 						class SR_Load {
 							icon = QUOTE(ICON_PATH(load));
-							statement = QUOTE(call FUNC(loadSRSettings));
+							statement = QUOTE([true] call FUNC(loadSRSettings));
 							displayName = "Load";
 						};
 						class SR_Save {
 							icon = QUOTE(ICON_PATH(save));
-							statement = QUOTE(call FUNC(saveSRSettings));
+							statement = QUOTE([true] call FUNC(saveSRSettings));
 							displayName = "Save";
 						};
 					};
@@ -65,13 +65,13 @@ class CfgVehicles {
 						class Save_LR {
 							displayName = "LR";
 							icon = QUOTE(ICON_PATH(lr));
-							statement = QUOTE(call FUNC(saveLRSettings));
+							statement = QUOTE([true] call FUNC(saveLRSettings));
 							condition = QUOTE(SHOW_LR && HAS_LR);
 						};
 						class Save_SR {
 							icon = QUOTE(ICON_PATH(sr));
 							displayName = "SR";
-							statement = QUOTE(call FUNC(saveSRSettings));
+							statement = QUOTE([true] call FUNC(saveSRSettings));
 							condition = QUOTE(SHOW_SR && HAS_SR);
 						};
 					};
@@ -84,13 +84,13 @@ class CfgVehicles {
 						class Load_LR {
 							displayName = "LR";
 							icon = QUOTE(ICON_PATH(lr));
-							statement = QUOTE(call FUNC(loadLRSettings));
+							statement = QUOTE([true] call FUNC(loadLRSettings));
 							condition = QUOTE(SHOW_LR && HAS_LR);
 						};
 						class Load_SR {
 							displayName = "SR";
 							icon = QUOTE(ICON_PATH(sr));
-							statement = QUOTE(call FUNC(loadSRSettings));
+							statement = QUOTE([true] call FUNC(loadSRSettings));
 							condition = QUOTE(SHOW_SR && HAS_SR);
 						};
 						class Load_Both {

--- a/CHTR_TFAR_Setter/CfgVehicles.hpp
+++ b/CHTR_TFAR_Setter/CfgVehicles.hpp
@@ -3,6 +3,7 @@
 #define SHOW_LR call FUNC(showSRCheck)
 #define SHOW_SR call FUNC(showLRCheck)
 #define ALTERNATE_LAYOUT (call FUNC(layoutOptionCheck))
+#define SHORTCUT_ENABLED call FUNC(shortcutEnabledCheck)
 
 class CfgVehicles {
     class Man;
@@ -19,15 +20,16 @@ class CfgVehicles {
 						"notOnMap"
 					};
 					class Load_Both {
-							displayName = "Load Both";
-							icon = QUOTE(ICON_PATH(interact_root));
-							statement = QUOTE([true] call FUNC(loadBothSettings));
-							condition = QUOTE(!ALTERNATE_LAYOUT && SHOW_LR && SHOW_SR && HAS_LR && HAS_SR);
+						displayName = "Load Both";
+						icon = QUOTE(ICON_PATH(interact_root));
+						statement = QUOTE([true] call FUNC(loadBothSettings));
+						condition = QUOTE(!ALTERNATE_LAYOUT && SHOW_LR && SHOW_SR && HAS_LR && HAS_SR);
 					};
 					//Original Layout, ALTERNATE_LAYOUT = False
 					class LR_Root {
 						displayName = "LR";
 						icon = QUOTE(ICON_PATH(lr));
+						statement = QUOTE(if(SHORTCUT_ENABLED) then {[true] call FUNC(loadLRSettings)};);
 						condition = QUOTE(!ALTERNATE_LAYOUT && SHOW_LR && HAS_LR);
 						class LR_Load {
 							icon = QUOTE(ICON_PATH(load));
@@ -44,6 +46,7 @@ class CfgVehicles {
 					class SR_Root {
 						displayName = "SR";
 						icon = QUOTE(ICON_PATH(sr));
+						statement = QUOTE(if(SHORTCUT_ENABLED) then {[true] call FUNC(loadSRSettings)};);
 						condition = QUOTE(!ALTERNATE_LAYOUT && SHOW_SR && HAS_SR);
 						class SR_Load {
 							icon = QUOTE(ICON_PATH(load));
@@ -79,8 +82,8 @@ class CfgVehicles {
 					class Load_Root {
 						displayName = "Load";
 						icon = QUOTE(ICON_PATH(load));
-						statement = "";
-						condition = QUOTE(ALTERNATE_LAYOUT);
+						statement = QUOTE(if(SHORTCUT_ENABLED) then {[true] call FUNC(loadBothSettings)};);
+						condition = QUOTE(ALTERNATE_LAYOUT && );
 						class Load_LR {
 							displayName = "LR";
 							icon = QUOTE(ICON_PATH(lr));

--- a/CHTR_TFAR_Setter/CfgVehicles.hpp
+++ b/CHTR_TFAR_Setter/CfgVehicles.hpp
@@ -83,7 +83,7 @@ class CfgVehicles {
 						displayName = "Load";
 						icon = QUOTE(ICON_PATH(load));
 						statement = QUOTE(if(SHORTCUT_ENABLED) then {[true] call FUNC(loadBothSettings)};);
-						condition = QUOTE(ALTERNATE_LAYOUT && );
+						condition = QUOTE(ALTERNATE_LAYOUT);
 						class Load_LR {
 							displayName = "LR";
 							icon = QUOTE(ICON_PATH(lr));

--- a/CHTR_TFAR_Setter/XEH_preInit.sqf
+++ b/CHTR_TFAR_Setter/XEH_preInit.sqf
@@ -19,6 +19,16 @@ _currentProfile = _settings select _profileIndex;
 LOG("Profile Loaded: " + str _currentProfile);
 
 LOG("Creating CBA Addon Options");
+_lrShowRun = {
+	params [["_value", false]];
+	[0, _value] call FUNC(setPrefs);
+	LOG("LR Setting Changed");
+};
+_srShowRun = {
+	params [["_value", false]];
+	[1, _value] call FUNC(setPrefs);
+	LOG("SR Setting Changed");
+};
 _alternateLayoutRun = {
 	params [
 		["_value", false]
@@ -26,24 +36,19 @@ _alternateLayoutRun = {
 	[2, _value] call FUNC(setPrefs);
 	LOG("Layout Setting Changed");
 };
-
-_lrShowRun = {
+_shortcutEnabledRun = {
 	params [["_value", false]];
-	[0, _value] call FUNC(setPrefs);
-	LOG("LR Setting Changed");
-};
-
-_srShowRun = {
-	params [["_value", false]];
-	[1, _value] call FUNC(setPrefs);
-	LOG("SR Setting Changed");
+	[3, _value] call FUNC(setPrefs);
+	LOG("ShortcutEnabled Setting Changed");
 };
 
 _layoutDefault = [] call FUNC(layoutOptionCheck);
 _lrDefault = [] call FUNC(showLRCheck);
 _srDefault = [] call FUNC(showSRCheck);
+_shortcutEnabled = [] call FUNC(shortcutEnabledCheck);
 
 [QUOTE(GVAR(Layout)), "CHECKBOX", ["Alternate Layout", "Change Tree Layout"], "ACE TFAR Radio Setter", _layoutDefault, 0, _alternateLayoutRun] call cba_settings_fnc_init;
+[QUOTE(GVAR(Shortcut)), "CHECKBOX", ["Enable Load Shortcuts", "Turn Off/On ability to use root lr/sr icon to load settings"], "ACE TFAR Radio Setter", _shortcutEnabled, 0, _shortcutEnabledRun] call cba_settings_fnc_init;
 [QUOTE(GVAR(ShowLR)), "CHECKBOX", ["LR Load/Save On", "Turn Off/On ability to set LR"], "ACE TFAR Radio Setter", _lrDefault, 0, _lrShowRun] call cba_settings_fnc_init;
 [QUOTE(GVAR(ShowSR)), "CHECKBOX", ["SR Load/Save On", "Turn Off/On ability to set SR"], "ACE TFAR Radio Setter", _srDefault, 0, _srShowRun] call cba_settings_fnc_init;
 

--- a/CHTR_TFAR_Setter/XEH_preInit.sqf
+++ b/CHTR_TFAR_Setter/XEH_preInit.sqf
@@ -1,7 +1,33 @@
 #include "functions\function_macros.hpp"
+
+GVAR(Settings) = profileNamespace getVariable [QUOTE(GVAR(Settings)), []];
+GVAR(Profile) = profileNamespace getVariable [QUOTE(GVAR(Profile)), -1];
+
+if(GVAR(Profile) == -1) then {
+	LOG("No Profile Selected, Defaulting to 0");
+	GVAR(Profile) = 0;
+};
+
+if(count GVAR(Settings) == 0) then {
+	LOG("Initialising profileNamespace Variables");
+	_settings = [
+		[0, "Default Profile", [], [], []]
+	];
+	profileNamespace setVariable [QUOTE(GVAR(Settings)), _settings];
+	GVAR(Profile) = 0;
+	GVAR(Settings) = profileNamespace getVariable [QUOTE(GVAR(Settings)), []];
+	LOG[format["Settings set to %1", GVAR(Settings)]];
+};
+
+if(count GVAR(Settings) == 0) exitWith {
+	LOG_ERROR(QUOTE(Failed to intialise from profileNamespace));
+	GVAR(Settings) = [];
+};
+
 _layoutDefault = call FUNC(layoutOptionCheck);
 _lrDefault = call FUNC(layoutOptionCheck);
 _srDefault = call FUNC(layoutOptionCheck);
-[QUOTE(PROFILESETTINGS_PREF_LAYOUT), "CHECKBOX", ["Alternate Layout", "Change Tree Layout"], "ACE TFAR Radio Setter", _layoutDefault, nil, {params [["_value", false]]; profileNamespace setVariable [QUOTE(PROFILESETTINGS_PREF_LAYOUT) , _value]; diag_log "Layout Setting Changed";}] call cba_settings_fnc_init;
-[QUOTE(PROFILESETTINGS_PREF_LR), "CHECKBOX", ["LR Load/Save On", "Turn Off/On ability to set LR"], "ACE TFAR Radio Setter", _lrDefault, nil, {params [["_value", false]]; profileNamespace setVariable [QUOTE(PROFILESETTINGS_PREF_LR) , _value]; diag_log format["LR Setting Changed", profileNamespace getVariable QUOTE(PROFILESETTINGS_PREF_LR)];}] call cba_settings_fnc_init;
-[QUOTE(PROFILESETTINGS_PREF_SR), "CHECKBOX", ["SR Load/Save On", "Turn Off/On ability to set SR"], "ACE TFAR Radio Setter", _srDefault, nil, {params [["_value", false]]; profileNamespace setVariable [QUOTE(PROFILESETTINGS_PREF_SR) , _value]; diag_log "SR Setting Changed";}] call cba_settings_fnc_init;
+
+["ALTERNATE_LAYOUT", "CHECKBOX", ["Alternate Layout", "Change Tree Layout"], "ACE TFAR Radio Setter", call FUNC(layoutOptionCheck), nil, {params [["_value", false]]; [2, _value] call FUNC(setPrefs); LOG("Layout Setting Changed")}] call cba_settings_fnc_init;
+["SHOW_LR", "CHECKBOX", ["LR Load/Save On", "Turn Off/On ability to set LR"], "ACE TFAR Radio Setter", call FUNC(showSRCheck), nil, {params [["_value", false]]; [0, _value] call FUNC(setPrefs); , _value]; LOG("LR Setting Changed"))}] call cba_settings_fnc_init;
+["SHOW_SR", "CHECKBOX", ["SR Load/Save On", "Turn Off/On ability to set SR"], "ACE TFAR Radio Setter", call FUNC(showLRCheck), nil, {params [["_value", false]]; [1, _value] call FUNC(setPrefs); , _value]; LOG("SR Setting Changed")}] call cba_settings_fnc_init;

--- a/CHTR_TFAR_Setter/XEH_preInit.sqf
+++ b/CHTR_TFAR_Setter/XEH_preInit.sqf
@@ -1,8 +1,11 @@
 #include "functions\function_macros.hpp"
 
+LOG("Loading Settings");
 _settings = call FUNC(loadSettings);
 _profileIndex = (_settings select 0) + 1;
-LOG(format["'%1' Profiles Loaded", (count _settings)-1]);
+_numProfiles = (count _settings)-1;
+
+LOG(format["'%1' Profiles Loaded", _numProfiles]);
 
 //not >= since it increments 1 larger than usual
 if(_profileIndex < 1 || _profileIndex > count _settings) then { 
@@ -13,8 +16,9 @@ if(_profileIndex < 1 || _profileIndex > count _settings) then {
 
 _currentProfile = _settings select _profileIndex;
 
-LOG(format["Selected profile(%1): '%2'", (_profileIndex-1), _currentProfile]);
+LOG("Profile Loaded: " + str _currentProfile);
 
+LOG("Creating CBA Addon Options");
 _alternateLayoutRun = {
 	params [
 		["_value", false]
@@ -42,3 +46,5 @@ _srDefault = [] call FUNC(showSRCheck);
 [QUOTE(GVAR(Layout)), "CHECKBOX", ["Alternate Layout", "Change Tree Layout"], "ACE TFAR Radio Setter", _layoutDefault, 0, _alternateLayoutRun] call cba_settings_fnc_init;
 [QUOTE(GVAR(ShowLR)), "CHECKBOX", ["LR Load/Save On", "Turn Off/On ability to set LR"], "ACE TFAR Radio Setter", _lrDefault, 0, _lrShowRun] call cba_settings_fnc_init;
 [QUOTE(GVAR(ShowSR)), "CHECKBOX", ["SR Load/Save On", "Turn Off/On ability to set SR"], "ACE TFAR Radio Setter", _srDefault, 0, _srShowRun] call cba_settings_fnc_init;
+
+LOG("PreInit Complete");

--- a/CHTR_TFAR_Setter/XEH_preInit.sqf
+++ b/CHTR_TFAR_Setter/XEH_preInit.sqf
@@ -1,33 +1,67 @@
 #include "functions\function_macros.hpp"
+#define SETTINGS GVAR(Settings)
+#define PROFILE GVAR(Profile)
 
-GVAR(Settings) = profileNamespace getVariable [QUOTE(GVAR(Settings)), []];
-GVAR(Profile) = profileNamespace getVariable [QUOTE(GVAR(Profile)), -1];
+SETTINGS = profileNamespace getVariable [QUOTE(SETTINGS), []];
+PROFILE = profileNamespace getVariable [QUOTE(PROFILE), -1];
 
-if(GVAR(Profile) == -1) then {
-	LOG("No Profile Selected, Defaulting to 0");
-	GVAR(Profile) = 0;
-};
-
-if(count GVAR(Settings) == 0) then {
+if(count SETTINGS == 0) then {
 	LOG("Initialising profileNamespace Variables");
 	_settings = [
 		[0, "Default Profile", [], [], []]
 	];
-	profileNamespace setVariable [QUOTE(GVAR(Settings)), _settings];
-	GVAR(Profile) = 0;
-	GVAR(Settings) = profileNamespace getVariable [QUOTE(GVAR(Settings)), []];
-	LOG[format["Settings set to %1", GVAR(Settings)]];
+	profileNamespace setVariable [QUOTE(SETTINGS), _settings];
+	profileNamespace setVariable [QUOTE(PROFILE), 0];
+	PROFILE = 0;
+	SETTINGS = profileNamespace getVariable [QUOTE(SETTINGS), []];
+	LOG(format["Settings set to %1", SETTINGS]);
 };
 
-if(count GVAR(Settings) == 0) exitWith {
+if(count SETTINGS == 0) exitWith {
 	LOG_ERROR(QUOTE(Failed to intialise from profileNamespace));
-	GVAR(Settings) = [];
+	SETTINGS = [];
 };
 
-_layoutDefault = call FUNC(layoutOptionCheck);
-_lrDefault = call FUNC(layoutOptionCheck);
-_srDefault = call FUNC(layoutOptionCheck);
+LOG(format["%1 Profiles Loaded", count SETTINGS]);
 
-["ALTERNATE_LAYOUT", "CHECKBOX", ["Alternate Layout", "Change Tree Layout"], "ACE TFAR Radio Setter", call FUNC(layoutOptionCheck), nil, {params [["_value", false]]; [2, _value] call FUNC(setPrefs); LOG("Layout Setting Changed")}] call cba_settings_fnc_init;
-["SHOW_LR", "CHECKBOX", ["LR Load/Save On", "Turn Off/On ability to set LR"], "ACE TFAR Radio Setter", call FUNC(showSRCheck), nil, {params [["_value", false]]; [0, _value] call FUNC(setPrefs); , _value]; LOG("LR Setting Changed"))}] call cba_settings_fnc_init;
-["SHOW_SR", "CHECKBOX", ["SR Load/Save On", "Turn Off/On ability to set SR"], "ACE TFAR Radio Setter", call FUNC(showLRCheck), nil, {params [["_value", false]]; [1, _value] call FUNC(setPrefs); , _value]; LOG("SR Setting Changed")}] call cba_settings_fnc_init;
+if(typeName PROFILE != typeName 0 || PROFILE == -1) then {
+	LOG("No Profile Selected, Defaulting to 0");
+	PROFILE = 0;
+}else
+{
+	_res = SETTINGS select PROFILE;
+	LOG(format["Selected profile: %1 -- %2", PROFILE, _res]);
+};
+
+if(PROFILE > count SETTINGS) then {
+	_safe = (count SETTINGS) - 1;
+	LOG(format["%1 references index larger than size of %2, resolving to %3", QUOTE(PROFILE), QUOTE(SETTINGS), _safe]);
+	PROFILE = _safe;
+	profileNamespace setVariable [QUOTE(PROFILE), PROFILE];
+};
+
+_alternateLayoutRun = {
+	params [["_value", false]]; 
+	[2, _value] call FUNC(setPrefs);
+	LOG("Layout Setting Changed");
+};
+
+_lrShowRun = {
+	params [["_value", false]];
+	[0, _value] call FUNC(setPrefs);
+	LOG("LR Setting Changed");
+};
+
+_srShowRun = {
+	params [["_value", false]];
+	[1, _value] call FUNC(setPrefs);
+	LOG("SR Setting Changed");
+};
+
+_layoutDefault = [] call FUNC(layoutOptionCheck);
+_lrDefault = [] call FUNC(showLRCheck);
+_srDefault = [] call FUNC(showSRCheck);
+
+_a = [QUOTE(GVAR(Layout)), "CHECKBOX", ["Alternate Layout", "Change Tree Layout"], "ACE TFAR Radio Setter", _layoutDefault, 0, _alternateLayoutRun] call cba_settings_fnc_init;
+_b = [QUOTE(GVAR(ShowLR)), "CHECKBOX", ["LR Load/Save On", "Turn Off/On ability to set LR"], "ACE TFAR Radio Setter", _lrDefault, 0, _lrShowRun] call cba_settings_fnc_init;
+_c = [QUOTE(GVAR(ShowSR)), "CHECKBOX", ["SR Load/Save On", "Turn Off/On ability to set SR"], "ACE TFAR Radio Setter", _srDefault, 0, _srShowRun] call cba_settings_fnc_init;

--- a/CHTR_TFAR_Setter/XEH_preInit.sqf
+++ b/CHTR_TFAR_Setter/XEH_preInit.sqf
@@ -1,47 +1,24 @@
 #include "functions\function_macros.hpp"
-#define SETTINGS GVAR(Settings)
-#define PROFILE GVAR(Profile)
 
-SETTINGS = profileNamespace getVariable [QUOTE(SETTINGS), []];
-PROFILE = profileNamespace getVariable [QUOTE(PROFILE), -1];
+_settings = call FUNC(loadSettings);
+_profileIndex = (_settings select 0) + 1;
+LOG(format["'%1' Profiles Loaded", (count _settings)-1]);
 
-if(count SETTINGS == 0) then {
-	LOG("Initialising profileNamespace Variables");
-	_settings = [
-		[0, "Default Profile", [], [], []]
-	];
-	profileNamespace setVariable [QUOTE(SETTINGS), _settings];
-	profileNamespace setVariable [QUOTE(PROFILE), 0];
-	PROFILE = 0;
-	SETTINGS = profileNamespace getVariable [QUOTE(SETTINGS), []];
-	LOG(format["Settings set to %1", SETTINGS]);
+//not >= since it increments 1 larger than usual
+if(_profileIndex < 1 || _profileIndex > count _settings) then { 
+	 //1 is effectively 0, but select 0 is profileIndex not profile
+	_profileIndex = 1;
+	_settings set [0, _profileIndex];
 };
 
-if(count SETTINGS == 0) exitWith {
-	LOG_ERROR(QUOTE(Failed to intialise from profileNamespace));
-	SETTINGS = [];
-};
+_currentProfile = _settings select _profileIndex;
 
-LOG(format["%1 Profiles Loaded", count SETTINGS]);
-
-if(typeName PROFILE != typeName 0 || PROFILE == -1) then {
-	LOG("No Profile Selected, Defaulting to 0");
-	PROFILE = 0;
-}else
-{
-	_res = SETTINGS select PROFILE;
-	LOG(format["Selected profile: %1 -- %2", PROFILE, _res]);
-};
-
-if(PROFILE > count SETTINGS) then {
-	_safe = (count SETTINGS) - 1;
-	LOG(format["%1 references index larger than size of %2, resolving to %3", QUOTE(PROFILE), QUOTE(SETTINGS), _safe]);
-	PROFILE = _safe;
-	profileNamespace setVariable [QUOTE(PROFILE), PROFILE];
-};
+LOG(format["Selected profile(%1): '%2'", (_profileIndex-1), _currentProfile]);
 
 _alternateLayoutRun = {
-	params [["_value", false]]; 
+	params [
+		["_value", false]
+	]; 
 	[2, _value] call FUNC(setPrefs);
 	LOG("Layout Setting Changed");
 };
@@ -62,6 +39,6 @@ _layoutDefault = [] call FUNC(layoutOptionCheck);
 _lrDefault = [] call FUNC(showLRCheck);
 _srDefault = [] call FUNC(showSRCheck);
 
-_a = [QUOTE(GVAR(Layout)), "CHECKBOX", ["Alternate Layout", "Change Tree Layout"], "ACE TFAR Radio Setter", _layoutDefault, 0, _alternateLayoutRun] call cba_settings_fnc_init;
-_b = [QUOTE(GVAR(ShowLR)), "CHECKBOX", ["LR Load/Save On", "Turn Off/On ability to set LR"], "ACE TFAR Radio Setter", _lrDefault, 0, _lrShowRun] call cba_settings_fnc_init;
-_c = [QUOTE(GVAR(ShowSR)), "CHECKBOX", ["SR Load/Save On", "Turn Off/On ability to set SR"], "ACE TFAR Radio Setter", _srDefault, 0, _srShowRun] call cba_settings_fnc_init;
+[QUOTE(GVAR(Layout)), "CHECKBOX", ["Alternate Layout", "Change Tree Layout"], "ACE TFAR Radio Setter", _layoutDefault, 0, _alternateLayoutRun] call cba_settings_fnc_init;
+[QUOTE(GVAR(ShowLR)), "CHECKBOX", ["LR Load/Save On", "Turn Off/On ability to set LR"], "ACE TFAR Radio Setter", _lrDefault, 0, _lrShowRun] call cba_settings_fnc_init;
+[QUOTE(GVAR(ShowSR)), "CHECKBOX", ["SR Load/Save On", "Turn Off/On ability to set SR"], "ACE TFAR Radio Setter", _srDefault, 0, _srShowRun] call cba_settings_fnc_init;

--- a/CHTR_TFAR_Setter/config.cpp
+++ b/CHTR_TFAR_Setter/config.cpp
@@ -29,6 +29,7 @@ class CfgFunctions {
 			class setPrefs {};
 			class getRadioData {};
 			class setRadioData {};
+			class loadSettings {};
         };
 	};
 };

--- a/CHTR_TFAR_Setter/config.cpp
+++ b/CHTR_TFAR_Setter/config.cpp
@@ -31,6 +31,7 @@ class CfgFunctions {
 			class setRadioData {};
 			class loadSettings {};
 			class setProfile {};
+			class copyLegacyRadioData {};
         };
 	};
 };

--- a/CHTR_TFAR_Setter/config.cpp
+++ b/CHTR_TFAR_Setter/config.cpp
@@ -30,6 +30,7 @@ class CfgFunctions {
 			class getRadioData {};
 			class setRadioData {};
 			class loadSettings {};
+			class setProfile {};
         };
 	};
 };

--- a/CHTR_TFAR_Setter/config.cpp
+++ b/CHTR_TFAR_Setter/config.cpp
@@ -32,6 +32,7 @@ class CfgFunctions {
 			class loadSettings {};
 			class setProfile {};
 			class copyLegacyRadioData {};
+			class shortcutEnabledCheck {};
         };
 	};
 };

--- a/CHTR_TFAR_Setter/config.cpp
+++ b/CHTR_TFAR_Setter/config.cpp
@@ -25,6 +25,10 @@ class CfgFunctions {
 			class showSRCheck {};
 			class layoutOptionCheck {};
 			class loadBothSettings {};
+			class getPrefs {};
+			class setPrefs {};
+			class getRadioData {};
+			class setRadioData {};
         };
 	};
 };

--- a/CHTR_TFAR_Setter/config_macros.hpp
+++ b/CHTR_TFAR_Setter/config_macros.hpp
@@ -5,3 +5,4 @@
 #define FUNCTION_PATH ADDON##\functions
 #define ICON_PATH(icon_name) ADDON##\ui\##icon_name##.paa
 #define COMPILE_FILE(name) compile preprocessFileLineNumbers 'ADDON\##name##.sqf'
+#define GVAR(name) ADDON##_##name

--- a/CHTR_TFAR_Setter/functions/defaults.hpp
+++ b/CHTR_TFAR_Setter/functions/defaults.hpp
@@ -3,3 +3,8 @@
 //[showLR, showSR, alternateLayout, loadShortcutsEnabled]
 #define PREFS_DEFAULT [true, true, false, false]
 #define PREFS_INDEX 4
+//Prefs Indexes
+#define SHOWLR_INDEX 0
+#define SHOWSR_INDEX 1
+#define ALTERNATELAYOUT_INDEX 2
+#define SHORTCUTENABLED_INDEX 3

--- a/CHTR_TFAR_Setter/functions/defaults.hpp
+++ b/CHTR_TFAR_Setter/functions/defaults.hpp
@@ -1,0 +1,5 @@
+//[currentProfileIndex, [profileID, profileDisplayName, lrData, srData, prefs]]
+#define SETTINGS_DEFAULT [0, [0, "Default Profile", [], [], []]]
+//[showLR, showSR, alternateLayout, loadShortcutsEnabled]
+#define PREFS_DEFAULT [true, true, false, false]
+#define PREFS_INDEX 4

--- a/CHTR_TFAR_Setter/functions/fn_copyLegacyRadioData.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_copyLegacyRadioData.sqf
@@ -1,11 +1,26 @@
+/*
+ * Author: M3ales
+ * Copies LR/SR data from the old version of CHTR_TFAR_QoL, also deletes vars (setting to nil) once loaded.
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * call CHTR_TFAR_Setter_fnc_copyLegacyRadioData
+ *
+ * Public: No
+ */
 #include "function_macros.hpp"
-//macro to make more readable, will 'delete' variable specified from profileNamespace
-#define DELETE_VAR(name) profileNamespace setVariable [name, nil];
+//checks var is both an array and non 0 count
+#define IS_SET(varname) typeName varname == typeName [] && count varname != 0
 //macros for legacy names
 #define LEGACY_SETTINGS_LR "CHTR_TFAR_QoL_SettingsLR"
 #define LEGACY_SETTINGS_SR "CHTR_TFAR_QoL_SettingsSR"
-//checks var is both an array and non 0 count
-#define IS_SET(varname) typeName varname == typeName [] && count varname != 0
+//macro to make more readable, will 'delete' variable specified from profileNamespace
+#define DELETE_VAR(name) profileNamespace setVariable [name, nil];
 
 LOG("Checking for Legacy Radio Data");
 _oldLRData = profileNamespace getVariable [LEGACY_SETTINGS_LR, []];

--- a/CHTR_TFAR_Setter/functions/fn_copyLegacyRadioData.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_copyLegacyRadioData.sqf
@@ -1,0 +1,30 @@
+#include "function_macros.hpp"
+//macro to make more readable, will 'delete' variable specified from profileNamespace
+#define DELETE_VAR(name) profileNamespace setVariable [name, nil];
+//macros for legacy names
+#define LEGACY_SETTINGS_LR "CHTR_TFAR_QoL_SettingsLR"
+#define LEGACY_SETTINGS_SR "CHTR_TFAR_QoL_SettingsSR"
+//checks var is both an array and non 0 count
+#define IS_SET(varname) typeName varname == typeName [] && count varname != 0
+
+LOG("Checking for Legacy Radio Data");
+_oldLRData = profileNamespace getVariable [LEGACY_SETTINGS_LR, []];
+_oldSRData = profileNamespace getVariable [LEGACY_SETTINGS_SR, []];
+if(IS_SET(_oldLRData) || IS_SET(_oldSRData)) then {
+	LOG("Legacy Radio Data found");
+	if(count _oldLRData != 0) then {
+		LOG("Copying Legacy LR Radio Data");
+		[true, _oldLRData] call FUNC(setRadioData);
+		LOG("Deleting Legacy LR Radio Data");
+		DELETE_VAR(LEGACY_SETTINGS_LR);
+	};
+	if(count _oldSRData != 0) then {
+		LOG("Copying Legacy SR Radio Data");
+		[false, _oldSRData] call FUNC(setRadioData);
+		LOG("Deleting Legacy SR Radio Data");
+		DELETE_VAR(LEGACY_SETTINGS_SR);
+	};
+}else
+{
+	LOG("No Legacy Radio Data found");
+};

--- a/CHTR_TFAR_Setter/functions/fn_getPrefs.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_getPrefs.sqf
@@ -14,7 +14,7 @@ _currentProfile = _settings select _profileIndex;
 
 _prefs = _currentProfile select 4;
 if(count _prefs == 0) then {
-	LOG("Init Prefs");
+	LOG("Prefs empty, Initialising to defaults");
 	_prefs append [true, true, false];
 };
 

--- a/CHTR_TFAR_Setter/functions/fn_getPrefs.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_getPrefs.sqf
@@ -1,8 +1,8 @@
 #include "function_macros.hpp"
 #include "defaults.hpp"
 params[["_index", 0, [0]]];
-if(_index < 0 || _index > 2) exitWith {
-	LOG_ERROR(format["Index %1 out of range at fnc_getPrefs.sqf", _index]);
+if(_index < 0 || _index >= count PREFS_DEFAULT) exitWith {
+	LOG_ERROR(format[QUOTE(Index %1 out of range at __FILE__), _index]);
 	[]
 };
 _settings = call FUNC(loadSettings);

--- a/CHTR_TFAR_Setter/functions/fn_getPrefs.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_getPrefs.sqf
@@ -1,0 +1,17 @@
+#include "function_macros.hpp"
+params[["_index", 0, [0]]];
+if(_index < 0 || _index > 2) exitWith {
+	LOG_ERROR(format["Index %1 out of range at fnc_getPrefs.sqf", _index]);
+	[]
+};
+if(count GVAR(Settings) == 0) exitWith {
+	LOG_ERROR(QUOTE(GVAR(SETTINGS) not initialised));
+	[]
+};
+_prefs = GVAR(Settings) select GVAR(Profile) select 4;
+if(count _prefs == 0) then {
+	LOG("Init Prefs");
+	_prefs = [true, true, false];
+};
+
+_prefs select _index

--- a/CHTR_TFAR_Setter/functions/fn_getPrefs.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_getPrefs.sqf
@@ -1,3 +1,18 @@
+/*
+ * Author: M3ales
+ * Gets one of the preference items from settings gvar, initialises to defaults if unset
+ *
+ * Arguments:
+ * 0: integer index of the preference requesting to be read <INTEGER>
+ *
+ * Return Value:
+ * The preference at the specified index
+ *
+ * Example:
+ * [0] call CHTR_TFAR_Setter_fnc_getPrefs
+ *
+ * Public: No
+ */
 #include "function_macros.hpp"
 #include "defaults.hpp"
 params[["_index", 0, [0]]];

--- a/CHTR_TFAR_Setter/functions/fn_getPrefs.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_getPrefs.sqf
@@ -4,14 +4,18 @@ if(_index < 0 || _index > 2) exitWith {
 	LOG_ERROR(format["Index %1 out of range at fnc_getPrefs.sqf", _index]);
 	[]
 };
-if(count GVAR(Settings) == 0) exitWith {
+_settings = call FUNC(loadSettings);
+if(count _settings == 0) exitWith {
 	LOG_ERROR(QUOTE(GVAR(SETTINGS) not initialised));
 	[]
 };
-_prefs = GVAR(Settings) select GVAR(Profile) select 4;
+_profileIndex = (_settings select 0) + 1;
+_currentProfile = _settings select _profileIndex;
+
+_prefs = _currentProfile select 4;
 if(count _prefs == 0) then {
 	LOG("Init Prefs");
-	_prefs = [true, true, false];
+	_prefs append [true, true, false];
 };
 
 _prefs select _index

--- a/CHTR_TFAR_Setter/functions/fn_getPrefs.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_getPrefs.sqf
@@ -1,4 +1,5 @@
 #include "function_macros.hpp"
+#include "defaults.hpp"
 params[["_index", 0, [0]]];
 if(_index < 0 || _index > 2) exitWith {
 	LOG_ERROR(format["Index %1 out of range at fnc_getPrefs.sqf", _index]);
@@ -12,10 +13,10 @@ if(count _settings == 0) exitWith {
 _profileIndex = (_settings select 0) + 1;
 _currentProfile = _settings select _profileIndex;
 
-_prefs = _currentProfile select 4;
+_prefs = _currentProfile select PREFS_INDEX;
 if(count _prefs == 0) then {
 	LOG("Prefs empty, Initialising to defaults");
-	_prefs append [true, true, false];
+	_prefs append PREFS_DEFAULT;
 };
 
 _prefs select _index

--- a/CHTR_TFAR_Setter/functions/fn_getRadioData.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_getRadioData.sqf
@@ -1,5 +1,5 @@
 #include "function_macros.hpp"
-params[["_lr", true, [true, false]]];
+params[["_lr", true, [true]]];
 
 if(count GVAR(Settings) == 0) exitWith {
 	LOG_ERROR(QUOTE(GVAR(SETTINGS) not initialised));

--- a/CHTR_TFAR_Setter/functions/fn_getRadioData.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_getRadioData.sqf
@@ -1,15 +1,19 @@
 #include "function_macros.hpp"
-params[["_lr", true, [true]]];
+params[
+	["_lr", true, [true]]
+];
 
-if(count GVAR(Settings) == 0) exitWith {
+_settings = call FUNC(loadSettings);
+if(count _settings == 0) exitWith {
 	LOG_ERROR(QUOTE(GVAR(SETTINGS) not initialised));
 	[]
 };
+_profileIndex = (_settings select 0) + 1;
+_currentProfile = _settings select _profileIndex;
 
-if(_lr) then {
-	_index = 2;
-}else {
+_index = 2;
+if(!_lr) then {
 	_index = 3;
 };
 
-GVAR(Settings) select GVAR(Profile) select _index
+_currentProfile select _index

--- a/CHTR_TFAR_Setter/functions/fn_getRadioData.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_getRadioData.sqf
@@ -1,0 +1,15 @@
+#include "function_macros.hpp"
+params[["_lr", true, [true, false]]];
+
+if(count GVAR(Settings) == 0) exitWith {
+	LOG_ERROR(QUOTE(GVAR(SETTINGS) not initialised));
+	[]
+};
+
+if(_lr) then {
+	_index = 2;
+}else {
+	_index = 3;
+};
+
+GVAR(Settings) select GVAR(Profile) select _index

--- a/CHTR_TFAR_Setter/functions/fn_getRadioData.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_getRadioData.sqf
@@ -1,3 +1,18 @@
+/*
+ * Author: M3ales
+ * Gets either LR or SR radio data from the settings array and returns it
+ *
+ * Arguments:
+ * 0: LR if true, SR if False <BOOLEAN>
+ *
+ * Return Value:
+ * TFAR Radio Data <ARRAY>
+ *
+ * Example:
+ * [true] call CHTR_TFAR_Setter_fnc_getRadioData
+ *
+ * Public: No
+ */
 #include "function_macros.hpp"
 params[
 	["_lr", true, [true]]

--- a/CHTR_TFAR_Setter/functions/fn_layoutOptionCheck.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_layoutOptionCheck.sqf
@@ -1,2 +1,2 @@
 #include "function_macros.hpp"
-profileNamespace getVariable [QUOTE(PROFILESETTINGS_PREF_LAYOUT), false];
+[2] call FUNC(getPrefs);

--- a/CHTR_TFAR_Setter/functions/fn_layoutOptionCheck.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_layoutOptionCheck.sqf
@@ -1,2 +1,3 @@
 #include "function_macros.hpp"
-[2] call FUNC(getPrefs);
+#include "defaults.hpp"
+[ALTERNATELAYOUT_INDEX] call FUNC(getPrefs);

--- a/CHTR_TFAR_Setter/functions/fn_loadBothSettings.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_loadBothSettings.sqf
@@ -20,6 +20,7 @@
 
 params[["_showResult", true, [true]]];
 
+LOG("Loading LR and SR Settings");
 _resultLR = [false] call FUNC(loadLRSettings);
 _resultSR = [false] call FUNC(loadSRSettings);
 if(_resultLR == 0 && _resultSR == 0) then {

--- a/CHTR_TFAR_Setter/functions/fn_loadBothSettings.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_loadBothSettings.sqf
@@ -23,7 +23,7 @@ params[["_showResult", true, [true]]];
 _resultLR = [false] call FUNC(loadLRSettings);
 _resultSR = [false] call FUNC(loadSRSettings);
 if(_resultLR == 0 && _resultSR == 0) then {
-	diag_log "Loaded LR and SR successfully";
+	LOG("Loaded LR and SR successfully");
 	if(_showResult) then {
 		["Loaded LR and SR Settings", QUOTE(ICON_PATH(load))] call ace_common_fnc_displayTextPicture;
 	};

--- a/CHTR_TFAR_Setter/functions/fn_loadLRSettings.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_loadLRSettings.sqf
@@ -21,13 +21,13 @@
 params[["_showResult", true, [true]]];
 
 LOG("Loading LR Settings");
-_settings = [true] call FUNC(getRadioData);
-if(count _settings == 0) exitWith {
+_radioData = [true] call FUNC(getRadioData);
+if(count _radioData == 0) exitWith {
 	LOG_ERROR("Cannot load unset LR settings");
 	1
 };
-[(call TFAR_fnc_activeLrRadio) select 0, (call TFAR_fnc_activeLrRadio) select 1, _settings] call TFAR_fnc_setLrSettings;
-LOG(format["Loading LR Settings: %1", _settings]);
+[(call TFAR_fnc_activeLrRadio) select 0, (call TFAR_fnc_activeLrRadio) select 1, _radioData] call TFAR_fnc_setLrSettings;
+LOG(format["Loading LR Settings: %1", _radioData]);
 if(_showResult) then {
 	["Loaded LR Settings", QUOTE(ICON_PATH(load))] call ace_common_fnc_displayTextPicture;
 };

--- a/CHTR_TFAR_Setter/functions/fn_loadLRSettings.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_loadLRSettings.sqf
@@ -20,13 +20,13 @@
 
 params[["_showResult", true, [true]]];
 
-_settings = profileNamespace getVariable [QUOTE(PROFILESETTINGS_LR), []];
+_settings = [true] call FUNC(getRadioData);
 if(count _settings == 0) exitWith {
-	diag_log "Cannot load unset LR settings";
+	LOG_ERROR("Cannot load unset LR settings");
 	1
 };
 [(call TFAR_fnc_activeLrRadio) select 0, (call TFAR_fnc_activeLrRadio) select 1, _settings] call TFAR_fnc_setLrSettings;
-diag_log format["Loading LR Settings: %1", _settings];
+LOG(format["Loading LR Settings: %1", _settings]);
 if(_showResult) then {
 	["Loaded LR Settings", QUOTE(ICON_PATH(load))] call ace_common_fnc_displayTextPicture;
 };

--- a/CHTR_TFAR_Setter/functions/fn_loadLRSettings.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_loadLRSettings.sqf
@@ -20,6 +20,7 @@
 
 params[["_showResult", true, [true]]];
 
+LOG("Loading LR Settings");
 _settings = [true] call FUNC(getRadioData);
 if(count _settings == 0) exitWith {
 	LOG_ERROR("Cannot load unset LR settings");

--- a/CHTR_TFAR_Setter/functions/fn_loadSRSettings.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_loadSRSettings.sqf
@@ -6,7 +6,7 @@
  * 
  *
  * Arguments:
- * _showResult (optional): If true will display a message at the top right using ace_common_fnc_displayTextPicture on success
+ * 0: _showResult (optional): If true will display a message at the top right using ace_common_fnc_displayTextPicture on success
  *
  * Return Value:
  * None
@@ -19,14 +19,15 @@
 #include "function_macros.hpp"
 
 params[["_showResult", true, [true]]];
+
 LOG("Loading SR Settings");
-_settings = [false] call FUNC(getRadioData);
-if(count _settings == 0) exitWith {
+_radioData = [false] call FUNC(getRadioData);
+if(count _radioData == 0) exitWith {
 	LOG_ERROR("Cannot load unset SR settings");
 	1
 };
-[(call TFAR_fnc_activeSwRadio), _settings] call TFAR_fnc_setSwSettings;
-LOG(format["Loading SR Settings: %1", _settings]);
+[(call TFAR_fnc_activeSwRadio), _radioData] call TFAR_fnc_setSwSettings;
+LOG(format["Loading SR Settings: %1", _radioData]);
 if(_showResult) then {
 	["Loaded SR Settings", QUOTE(ICON_PATH(load))] call ace_common_fnc_displayTextPicture;
 };

--- a/CHTR_TFAR_Setter/functions/fn_loadSRSettings.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_loadSRSettings.sqf
@@ -20,13 +20,13 @@
 
 params[["_showResult", true, [true]]];
 
-_settings = profileNamespace getVariable [QUOTE(PROFILESETTINGS_SR), []];
+_settings = [false] call FUNC(getRadioData);
 if(count _settings == 0) exitWith {
-	diag_log "Cannot load unset SR settings";
+	LOG_ERROR("Cannot load unset SR settings");
 	1
 };
 [(call TFAR_fnc_activeSwRadio), _settings] call TFAR_fnc_setSwSettings;
-diag_log format["Loading SR Settings: %1", _settings];
+LOG(format["Loading SR Settings: %1", _settings]);
 if(_showResult) then {
 	["Loaded SR Settings", QUOTE(ICON_PATH(load))] call ace_common_fnc_displayTextPicture;
 };

--- a/CHTR_TFAR_Setter/functions/fn_loadSRSettings.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_loadSRSettings.sqf
@@ -19,7 +19,7 @@
 #include "function_macros.hpp"
 
 params[["_showResult", true, [true]]];
-
+LOG("Loading SR Settings");
 _settings = [false] call FUNC(getRadioData);
 if(count _settings == 0) exitWith {
 	LOG_ERROR("Cannot load unset SR settings");

--- a/CHTR_TFAR_Setter/functions/fn_loadSettings.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_loadSettings.sqf
@@ -1,3 +1,18 @@
+/*
+ * Authors: M3ales
+ * Loads settings data from public var, usable as reference due to array. Initialises to defaults if unset, and calls legacy copy when initialising.
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * Reference to _Settings profileNamespace var
+ *
+ * Example:
+ * call CHTR_TFAR_Setter_fnc_loadSettings
+ *
+ * Public: No
+ */
 #include "function_macros.hpp"
 #include "defaults.hpp"
 #define SETTINGS GVAR(Settings)

--- a/CHTR_TFAR_Setter/functions/fn_loadSettings.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_loadSettings.sqf
@@ -1,0 +1,28 @@
+#include "function_macros.hpp"
+#define SETTINGS GVAR(Settings)
+
+_settings = profileNamespace getVariable [QUOTE(SETTINGS), false];
+if(typeName _settings == typeName false) then {
+	LOG(format["%1 is unset", QUOTE(SETTINGS)]);
+	profileNamespace setVariable[QUOTE(SETTINGS), []];
+	_settings = profileNamespace getVariable [QUOTE(SETTINGS), false];
+	if(typeName _settings == typeName false) exitWith {
+		LOG_ERROR(format["Failed to set ", QUOTE(SETTINGS)]);
+		[]
+	}
+};
+
+if(count _settings == 0) then {
+	LOG("Initialising profileNamespace to defaults");
+	_defaults = 
+	[
+		0,
+		[0, "Default Profile", [], [], []]
+	];
+	_settings append _defaults;
+	if(count _settings == 0) exitWith {
+		LOG_ERROR("Failed to intialise profileNamespace to defaults");
+		[]
+	};
+};
+_settings

--- a/CHTR_TFAR_Setter/functions/fn_loadSettings.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_loadSettings.sqf
@@ -1,4 +1,5 @@
 #include "function_macros.hpp"
+#include "defaults.hpp"
 #define SETTINGS GVAR(Settings)
 
 _settings = profileNamespace getVariable [QUOTE(SETTINGS), false];
@@ -14,12 +15,7 @@ if(typeName _settings == typeName false) then {
 
 if(count _settings == 0) then {
 	LOG("Initialising profileNamespace to defaults");
-	_defaults = 
-	[
-		0,
-		[0, "Default Profile", [], [], []]
-	];
-	_settings append _defaults;
+	_settings append SETTINGS_DEFAULT;
 	if(count _settings == 0) exitWith {
 		LOG_ERROR("Failed to intialise profileNamespace to defaults");
 		[]

--- a/CHTR_TFAR_Setter/functions/fn_loadSettings.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_loadSettings.sqf
@@ -14,8 +14,10 @@ if(typeName _settings == typeName false) then {
 };
 
 if(count _settings == 0) then {
+	LOG("Looking for old radio data");
 	LOG("Initialising profileNamespace to defaults");
 	_settings append SETTINGS_DEFAULT;
+	call FUNC(copyLegacyRadioData);
 	if(count _settings == 0) exitWith {
 		LOG_ERROR("Failed to intialise profileNamespace to defaults");
 		[]

--- a/CHTR_TFAR_Setter/functions/fn_saveLRSettings.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_saveLRSettings.sqf
@@ -20,6 +20,7 @@
 
 params[["_showResult", true, [true]]];
 
+LOG("Saving LR Settings");
 _settings = (call TFAR_fnc_activeLrRadio) call TFAR_fnc_getLrSettings;
 [true, _settings] call FUNC(setRadioData);
 
@@ -27,4 +28,4 @@ if(_showResult) then {
 	["Saved LR Settings", QUOTE(ICON_PATH(interact_root))] call ace_common_fnc_displayTextPicture;
 };
 //check it saved correctly, return result
-[true] call FUNC(getRadioData) == _settings
+0

--- a/CHTR_TFAR_Setter/functions/fn_saveLRSettings.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_saveLRSettings.sqf
@@ -21,8 +21,8 @@
 params[["_showResult", true, [true]]];
 
 LOG("Saving LR Settings");
-_settings = (call TFAR_fnc_activeLrRadio) call TFAR_fnc_getLrSettings;
-[true, _settings] call FUNC(setRadioData);
+_radioData = (call TFAR_fnc_activeLrRadio) call TFAR_fnc_getLrSettings;
+[true, _radioData] call FUNC(setRadioData);
 
 if(_showResult) then {
 	["Saved LR Settings", QUOTE(ICON_PATH(interact_root))] call ace_common_fnc_displayTextPicture;

--- a/CHTR_TFAR_Setter/functions/fn_saveLRSettings.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_saveLRSettings.sqf
@@ -21,10 +21,10 @@
 params[["_showResult", true, [true]]];
 
 _settings = (call TFAR_fnc_activeLrRadio) call TFAR_fnc_getLrSettings;
-profileNamespace setVariable [QUOTE(PROFILESETTINGS_LR) , _settings];
-diag_log format["Saving LR Settings: %1", _settings];
+[true, _settings] call FUNC(setRadioData);
+
 if(_showResult) then {
 	["Saved LR Settings", QUOTE(ICON_PATH(interact_root))] call ace_common_fnc_displayTextPicture;
 };
 //check it saved correctly, return result
-profileNamespace getVariable QUOTE(PROFILESETTINGS_LR) == _settings
+[true] call FUNC(getRadioData) == _settings

--- a/CHTR_TFAR_Setter/functions/fn_saveSRSettings.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_saveSRSettings.sqf
@@ -20,10 +20,11 @@
 
 params[["_showResult", true, [true]]];
 
+LOG("Saving SR Settings");
 _settings = (call TFAR_fnc_activeSwRadio) call TFAR_fnc_getSwSettings;
 [false, _settings] call FUNC(setRadioData);
 if(_showResult) then {
 	["Saved SR Settings", QUOTE(ICON_PATH(interact_root))] call ace_common_fnc_displayTextPicture;
 };
 //check it saved correctly, return result
-[false] call FUNC(getRadioData) == _settings
+0

--- a/CHTR_TFAR_Setter/functions/fn_saveSRSettings.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_saveSRSettings.sqf
@@ -21,8 +21,9 @@
 params[["_showResult", true, [true]]];
 
 LOG("Saving SR Settings");
-_settings = (call TFAR_fnc_activeSwRadio) call TFAR_fnc_getSwSettings;
-[false, _settings] call FUNC(setRadioData);
+_radioData = (call TFAR_fnc_activeSwRadio) call TFAR_fnc_getSwSettings;
+[false, _radioData] call FUNC(setRadioData);
+
 if(_showResult) then {
 	["Saved SR Settings", QUOTE(ICON_PATH(interact_root))] call ace_common_fnc_displayTextPicture;
 };

--- a/CHTR_TFAR_Setter/functions/fn_saveSRSettings.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_saveSRSettings.sqf
@@ -21,10 +21,9 @@
 params[["_showResult", true, [true]]];
 
 _settings = (call TFAR_fnc_activeSwRadio) call TFAR_fnc_getSwSettings;
-profileNamespace setVariable [QUOTE(PROFILESETTINGS_SR) , _settings];
-diag_log format["Saving SR Settings: %1", _settings];
+[false, _settings] call FUNC(setRadioData);
 if(_showResult) then {
 	["Saved SR Settings", QUOTE(ICON_PATH(interact_root))] call ace_common_fnc_displayTextPicture;
 };
 //check it saved correctly, return result
-profileNamespace getVariable QUOTE(PROFILESETTINGS_SR) == _settings
+[false] call FUNC(getRadioData) == _settings

--- a/CHTR_TFAR_Setter/functions/fn_setPrefs.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_setPrefs.sqf
@@ -15,7 +15,7 @@ _currentProfile = _settings select _profileIndex;
 _prefs = _currentProfile select 4;
 
 if(count _prefs == 0) then {
-	LOG("Init Prefs");
+	LOG("Prefs empty, Initialising to defaults");
 	_currentProfile set [4, [true, true, false]];
 	_prefs = _currentProfile select 4; //ensure that the reference is preserved
 };

--- a/CHTR_TFAR_Setter/functions/fn_setPrefs.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_setPrefs.sqf
@@ -4,17 +4,19 @@ if(_index < 0 || _index > 2) exitWith {
 	LOG_ERROR(format["Index %1 out of range at fnc_setPrefs.sqf", _index]);
 	[]
 };
-if(count GVAR(Settings) == 0) exitWith {
+
+_settings = call FUNC(loadSettings);
+if(count _settings == 0) exitWith {
 	LOG_ERROR(QUOTE(GVAR(Settings) not initialised));
-	[]
 };
-_currentProfile = GVAR(Settings) select GVAR(Profile);
+
+_profileIndex = (_settings select 0) + 1; //0 is profile, therefore profile 0 = index 1
+_currentProfile = _settings select _profileIndex;
 _prefs = _currentProfile select 4;
+
 if(count _prefs == 0) then {
 	LOG("Init Prefs");
 	_currentProfile set [4, [true, true, false]];
 	_prefs = _currentProfile select 4; //ensure that the reference is preserved
 };
-
 _prefs set [_index, _value];
-LOG(format["Prefs updated to: %1", _prefs]);

--- a/CHTR_TFAR_Setter/functions/fn_setPrefs.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_setPrefs.sqf
@@ -1,6 +1,7 @@
 #include "function_macros.hpp"
+#include "defaults.hpp"
 params[["_index", 0, [0]], ["_value", true, [true]]];
-if(_index < 0 || _index > 2) exitWith {
+if(_index < 0 || _index >= count PREFS_DEFAULT) exitWith {
 	LOG_ERROR(format["Index %1 out of range at fnc_setPrefs.sqf", _index]);
 	[]
 };
@@ -12,11 +13,11 @@ if(count _settings == 0) exitWith {
 
 _profileIndex = (_settings select 0) + 1; //0 is profile, therefore profile 0 = index 1
 _currentProfile = _settings select _profileIndex;
-_prefs = _currentProfile select 4;
+_prefs = _currentProfile select PREFS_INDEX;
 
 if(count _prefs == 0) then {
 	LOG("Prefs empty, Initialising to defaults");
-	_currentProfile set [4, [true, true, false]];
-	_prefs = _currentProfile select 4; //ensure that the reference is preserved
+	_currentProfile set [PREFS_INDEX, PREFS_DEFAULT];
+	_prefs = _currentProfile select PREFS_INDEX; //ensure that the reference is preserved
 };
 _prefs set [_index, _value];

--- a/CHTR_TFAR_Setter/functions/fn_setPrefs.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_setPrefs.sqf
@@ -1,8 +1,24 @@
+/*
+ * Author: M3ales
+ * Modifies a single preference entry, intialises preferences if unset
+ *
+ * Arguments:
+ * 0: index of preference in _prefs array <INTEGER>
+ * 1: value to set the preference to <ANY>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [0, true] call CHTR_TFAR_Setter_fnc_setPrefs
+ *
+ * Public: No
+ */
 #include "function_macros.hpp"
 #include "defaults.hpp"
 params[["_index", 0, [0]], ["_value", true, [true]]];
 if(_index < 0 || _index >= count PREFS_DEFAULT) exitWith {
-	LOG_ERROR(format["Index %1 out of range at fnc_setPrefs.sqf", _index]);
+	LOG_ERROR(format[QUOTE(Index %1 out of range at __FILE__), _index]);
 	[]
 };
 

--- a/CHTR_TFAR_Setter/functions/fn_setPrefs.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_setPrefs.sqf
@@ -1,18 +1,20 @@
 #include "function_macros.hpp"
-params[["_index", 0, [0]], ["_value", true, [true, false]]];
+params[["_index", 0, [0]], ["_value", true, [true]]];
 if(_index < 0 || _index > 2) exitWith {
 	LOG_ERROR(format["Index %1 out of range at fnc_setPrefs.sqf", _index]);
 	[]
 };
 if(count GVAR(Settings) == 0) exitWith {
-	LOG_ERROR(QUOTE(GVAR(SETTINGS) not initialised));
+	LOG_ERROR(QUOTE(GVAR(Settings) not initialised));
 	[]
 };
-_prefs = GVAR(Settings) select GVAR(Profile) select 4;
+_currentProfile = GVAR(Settings) select GVAR(Profile);
+_prefs = _currentProfile select 4;
 if(count _prefs == 0) then {
 	LOG("Init Prefs");
-	_prefs = [true, true, false];
+	_currentProfile set [4, [true, true, false]];
+	_prefs = _currentProfile select 4; //ensure that the reference is preserved
 };
 
 _prefs set [_index, _value];
-LOG(format["Prefs updated to: %1", _prefs])
+LOG(format["Prefs updated to: %1", _prefs]);

--- a/CHTR_TFAR_Setter/functions/fn_setPrefs.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_setPrefs.sqf
@@ -1,0 +1,18 @@
+#include "function_macros.hpp"
+params[["_index", 0, [0]], ["_value", true, [true, false]]];
+if(_index < 0 || _index > 2) exitWith {
+	LOG_ERROR(format["Index %1 out of range at fnc_setPrefs.sqf", _index]);
+	[]
+};
+if(count GVAR(Settings) == 0) exitWith {
+	LOG_ERROR(QUOTE(GVAR(SETTINGS) not initialised));
+	[]
+};
+_prefs = GVAR(Settings) select GVAR(Profile) select 4;
+if(count _prefs == 0) then {
+	LOG("Init Prefs");
+	_prefs = [true, true, false];
+};
+
+_prefs set [_index, _value];
+LOG(format["Prefs updated to: %1", _prefs])

--- a/CHTR_TFAR_Setter/functions/fn_setProfile.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_setProfile.sqf
@@ -1,0 +1,13 @@
+#include "function_macros.hpp"
+params[
+	["_profileIndex", 0, [0]]
+];
+if(_profileIndex < 0) exitWith {
+	LOG_ERROR("Cannot set profile to index < 0");
+};
+_settings = FUNC(loadSettings);
+if(_profileIndex > (count _settings)-2) exitWith {
+	LOG_ERROR(format["Provided index %1 is too large, no profile matches it's index", _profileIndex]);
+};
+LOG(format["Updating Profile to %1", _profileIndex]);
+_settings set [0, _profileIndex];

--- a/CHTR_TFAR_Setter/functions/fn_setProfile.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_setProfile.sqf
@@ -1,3 +1,18 @@
+/*
+ * Author: M3ales
+ * Sets the current profile to the specified profileIndex, mimimal type checking at present, use with caution
+ *
+ * Arguments:
+ * 0: the index of the profile you want set as current, 0 based <INTEGER>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [0] call CHTR_TFAR_Setter_fnc_setProfile
+ *
+ * Public: No
+ */
 #include "function_macros.hpp"
 params[
 	["_profileIndex", 0, [0]]

--- a/CHTR_TFAR_Setter/functions/fn_setRadioData.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_setRadioData.sqf
@@ -1,16 +1,22 @@
 #include "function_macros.hpp"
-params[["_lr", true, [true]], ["_value", [], [[]]]];
 
-if(count GVAR(Settings) == 0) exitWith {
-	LOG_ERROR(QUOTE(GVAR(SETTINGS) not initialised));
-};
+params[
+	["_lr", true, [true]],
+	["_value", [], [[]]]
+];
 
-if(_lr) then {
-	_index = 2;
-}else {
+_log = format["Updating Radio (LR: %1) to: %2", _lr, _value];
+LOG(_log);
+
+_index = 2;
+if(!_lr) then {
 	_index = 3;
 };
 
-GVAR(Settings) select GVAR(Profile) set [_index, _value];
-_str = format["Updated [LR: %1] to: %2", _lr, _value];
-LOG(_str);
+_settings = call FUNC(loadSettings);
+if(count _settings == 0) exitWith {
+	LOG_ERROR(QUOTE(GVAR(SETTINGS) not initialised));
+};
+_profileIndex = (_settings select 0) + 1;
+_currentProfile = _settings select _profileIndex;
+_currentProfile set [_index, _value];

--- a/CHTR_TFAR_Setter/functions/fn_setRadioData.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_setRadioData.sqf
@@ -5,12 +5,13 @@ params[
 	["_value", [], [[]]]
 ];
 
-_log = format["Updating Radio (LR: %1) to: %2", _lr, _value];
-LOG(_log);
-
 _index = 2;
 if(!_lr) then {
+	LOG("Updating SR Radio");
 	_index = 3;
+}else
+{
+	LOG("Updating LR Radio");
 };
 
 _settings = call FUNC(loadSettings);

--- a/CHTR_TFAR_Setter/functions/fn_setRadioData.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_setRadioData.sqf
@@ -1,0 +1,15 @@
+#include "function_macros.hpp"
+params[["_lr", true, [true, false]], ["_value", [], [[]]]];
+
+if(count GVAR(Settings) == 0) exitWith {
+	LOG_ERROR(QUOTE(GVAR(SETTINGS) not initialised));
+};
+
+if(_lr) then {
+	_index = 2;
+}else {
+	_index = 3;
+};
+
+GVAR(Settings) select GVAR(Profile) set [_index, _value];
+LOG(format["Updated [LR: %1] to: %2", _lr, _value]);

--- a/CHTR_TFAR_Setter/functions/fn_setRadioData.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_setRadioData.sqf
@@ -1,3 +1,18 @@
+/*
+ * Author: M3ales
+ * Sets LR/SR data of current profile
+ *
+ * Arguments:
+ * 0: LR or SR, LR is true (default:true) <BOOLEAN>
+ * 1: Data to be saved (default: []) <ARRAY>
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [true, []] call CHTR_TFAR_Setter_fnc_setRadioData
+ *
+ * Public: No
+ */
 #include "function_macros.hpp"
 
 params[
@@ -7,11 +22,11 @@ params[
 
 _index = 2;
 if(!_lr) then {
-	LOG("Updating SR Radio");
+	LOG("Saving SR Radio Data");
 	_index = 3;
 }else
 {
-	LOG("Updating LR Radio");
+	LOG("Saving LR Radio Data");
 };
 
 _settings = call FUNC(loadSettings);

--- a/CHTR_TFAR_Setter/functions/fn_setRadioData.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_setRadioData.sqf
@@ -1,5 +1,5 @@
 #include "function_macros.hpp"
-params[["_lr", true, [true, false]], ["_value", [], [[]]]];
+params[["_lr", true, [true]], ["_value", [], [[]]]];
 
 if(count GVAR(Settings) == 0) exitWith {
 	LOG_ERROR(QUOTE(GVAR(SETTINGS) not initialised));
@@ -12,4 +12,5 @@ if(_lr) then {
 };
 
 GVAR(Settings) select GVAR(Profile) set [_index, _value];
-LOG(format["Updated [LR: %1] to: %2", _lr, _value]);
+_str = format["Updated [LR: %1] to: %2", _lr, _value];
+LOG(_str);

--- a/CHTR_TFAR_Setter/functions/fn_shortcutEnabledCheck.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_shortcutEnabledCheck.sqf
@@ -1,2 +1,3 @@
- #include "function_macros.hpp"
-[3] call FUNC(getPrefs);
+#include "function_macros.hpp"
+#include "defaults.hpp"
+[SHORTCUTENABLED_INDEX] call FUNC(getPrefs);

--- a/CHTR_TFAR_Setter/functions/fn_shortcutEnabledCheck.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_shortcutEnabledCheck.sqf
@@ -1,0 +1,2 @@
+ #include "function_macros.hpp"
+[3] call FUNC(getPrefs);

--- a/CHTR_TFAR_Setter/functions/fn_showLRCheck.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_showLRCheck.sqf
@@ -1,2 +1,2 @@
  #include "function_macros.hpp"
- profileNamespace getVariable [QUOTE(PROFILESETTINGS_PREF_LR), true];
+_showLR = [0] call FUNC(getPrefs);

--- a/CHTR_TFAR_Setter/functions/fn_showLRCheck.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_showLRCheck.sqf
@@ -1,2 +1,3 @@
- #include "function_macros.hpp"
-[0] call FUNC(getPrefs);
+#include "function_macros.hpp"
+#include "defaults.hpp"
+[SHOWLR_INDEX] call FUNC(getPrefs);

--- a/CHTR_TFAR_Setter/functions/fn_showLRCheck.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_showLRCheck.sqf
@@ -1,2 +1,2 @@
  #include "function_macros.hpp"
-_showLR = [0] call FUNC(getPrefs);
+[0] call FUNC(getPrefs);

--- a/CHTR_TFAR_Setter/functions/fn_showSRCheck.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_showSRCheck.sqf
@@ -1,2 +1,2 @@
  #include "function_macros.hpp"
-_showSR = [1] call FUNC(getPrefs);
+[1] call FUNC(getPrefs);

--- a/CHTR_TFAR_Setter/functions/fn_showSRCheck.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_showSRCheck.sqf
@@ -1,2 +1,3 @@
- #include "function_macros.hpp"
-[1] call FUNC(getPrefs);
+#include "function_macros.hpp"
+#include "defaults.hpp"
+[SHOWSR_INDEX] call FUNC(getPrefs);

--- a/CHTR_TFAR_Setter/functions/fn_showSRCheck.sqf
+++ b/CHTR_TFAR_Setter/functions/fn_showSRCheck.sqf
@@ -1,2 +1,2 @@
  #include "function_macros.hpp"
- profileNamespace getVariable [QUOTE(PROFILESETTINGS_PREF_SR), true];
+_showSR = [1] call FUNC(getPrefs);

--- a/CHTR_TFAR_Setter/functions/function_macros.hpp
+++ b/CHTR_TFAR_Setter/functions/function_macros.hpp
@@ -1,8 +1,4 @@
 #include "../config_macros.hpp"
-#define PROFILESETTINGS(suffix) ADDON##_Settings_##suffix
-#define PROFILESETTINGS_LR PROFILESETTINGS(LR)
-#define PROFILESETTINGS_SR PROFILESETTINGS(SR)
-#define PROFILESETTINGS_PREF_SR PROFILESETTINGS(Pref_SR)
-#define PROFILESETTINGS_PREF_LR PROFILESETTINGS(Pref_LR)
-#define PROFILESETTINGS_PREF_LAYOUT PROFILESETTINGS(Pref_Layout)
-// #define Q_DIAG_LOG_CHECK __FILE__  //Use: diag_log Q_DIAG_LOG_CHECK; Place in a fnc sqf to see if it is referenced.
+#define LOG_BASE(level,msg) diag_log format[QUOTE(ADDON[level]: %1), msg]
+#define LOG(msg) LOG_BASE(DEBUG,msg)
+#define LOG_ERROR(msg) LOG_BASE(ERR,msg)

--- a/CHTR_TFAR_Setter/functions/function_macros.hpp
+++ b/CHTR_TFAR_Setter/functions/function_macros.hpp
@@ -1,5 +1,5 @@
 #include "../config_macros.hpp"
 #define LOG_BASE(level,msg) diag_log format[QUOTE(ADDON[level]: %1), msg]
-#define LOG(msg) _dtmpstr = msg; \
-LOG_BASE(DEBUG,_str)
+#define LOG(msg) LOG_BASE(DEBUG,msg)
+#define LOG_F(fmt,args) LOG_BASE(DEBUG,format[fmt, args])
 #define LOG_ERROR(msg) LOG_BASE(ERR,msg)

--- a/CHTR_TFAR_Setter/functions/function_macros.hpp
+++ b/CHTR_TFAR_Setter/functions/function_macros.hpp
@@ -1,5 +1,4 @@
 #include "../config_macros.hpp"
 #define LOG_BASE(level,msg) diag_log format[QUOTE(ADDON[level]: %1), msg]
 #define LOG(msg) LOG_BASE(DEBUG,msg)
-#define LOG_F(fmt,args) LOG_BASE(DEBUG,format[fmt, args])
 #define LOG_ERROR(msg) LOG_BASE(ERR,msg)

--- a/CHTR_TFAR_Setter/functions/function_macros.hpp
+++ b/CHTR_TFAR_Setter/functions/function_macros.hpp
@@ -1,4 +1,5 @@
 #include "../config_macros.hpp"
 #define LOG_BASE(level,msg) diag_log format[QUOTE(ADDON[level]: %1), msg]
-#define LOG(msg) LOG_BASE(DEBUG,msg)
+#define LOG(msg) _dtmpstr = msg; \
+LOG_BASE(DEBUG,_str)
 #define LOG_ERROR(msg) LOG_BASE(ERR,msg)


### PR DESCRIPTION
## Changes
- Migrated to single storage variable for settings, `CHTR_TFAR_Setter_Settings` - multidimensional array.
- Structure of stored data is as follows:
    - Settings Example: `[0, [0, "Default Profile, [], [], []]]`
    - Settings: `[currentProfileIndex, [profileID, profileDisplayName, lrData, srData, prefs]]`
    - prefs: `[showLR, showSR, alternateLayout, loadShortcutsEnabled]`
- Helper methods for accessing and mutating data
- Macros to enhance clarity of diag log messages (LOG, LOG_ERROR)
- Added compatibility with previous storage system, will load vars from previous LR/SR saved data. (1.x)
- Auto loads legacy data on first startup, deletes vars after loading for cleanup.
